### PR TITLE
- checking for !isset() does not allow values of NULL to be validated…

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -460,7 +460,7 @@ class Model extends \Eden\Model\Index
     {
         $valid = array();
         foreach ($columns as $column) {
-            if (!isset($this->data[$column])) {
+            if(!isset($this->data[$column]) && !is_null($this->data[$column])) {
                 continue;
             }
             


### PR DESCRIPTION
…, !is_null must also be checked

Eden SQL is not able to update a field to NULL because it is checking for isset() which returns FALSE if the value is NULL.

NULL are valid values in MySQL...