### PR TITLE
Update on index.php to remove ctype_digit checking

### DIFF
--- a/src/Index.php
+++ b/src/Index.php
@@ -110,7 +110,7 @@ abstract class Index extends Base
             }
             
             return '('.implode(",", $value).')';
-        } else if (is_int($value) || ctype_digit($value)) {
+        } else if (is_int($value)) {
             return $value;
         }
         


### PR DESCRIPTION
Removing ctype_digit checking so that the function will not consider values leading with zero as integer

because of `ctype_digit` if you try to insert or query using a string starting with `0` like `02131231` it will think this is an integer and then insert the field into the SQL query directly without binding and thus MySQL will interpret this like

```sql
SELECT * FROM WHERE `field` = 02313213
```

instead of 

```sql
SELECT * FROM WHERE `field` = '02313213'
```